### PR TITLE
Feat: openid connect fixes

### DIFF
--- a/demo-project/demo-frontend/callback.js
+++ b/demo-project/demo-frontend/callback.js
@@ -1,14 +1,16 @@
-const params = new URLSearchParams(window.location.search);
-const accessToken = params.get('access_token');
+// get the id_token and refresh_token from the fragment part of the url
+// and store them in the session storage
+const params = new URLSearchParams(window.location.hash.slice(1));
+const idToken = params.get('id_token');
 const refreshToken = params.get('refresh_token');
 const state = params.get('state');
 
-if (accessToken && refreshToken && state) {
+if (idToken && refreshToken && state) {
     const fn = async ()=>{
         // use token to access protected route
         const resp = await fetch('/protected', {
             headers: {
-                Authorization: `Bearer ${accessToken}`
+                Authorization: `Bearer ${idToken}`
             }
         });
         const greeting = document.createElement('h2');

--- a/login-frontend/src/App.tsx
+++ b/login-frontend/src/App.tsx
@@ -46,16 +46,16 @@ function ExtensionSelector(props: { onSelect: (extension: object) => void, selec
 export function App() {
 
     const [extension, setExtension] = React.useState<any>(null);
-    const [loginResponse, setLoginResponse] = React.useState({accessToken: '', refreshToken: ''});
+    const [loginResponse, setLoginResponse] = React.useState({idToken: '', refreshToken: ''});
     const [error, setError] = React.useState('');
 
     React.useEffect(() => {
         // check for query parameters access_token and refresh_token
         const urlParams = new URLSearchParams(window.location.search)
-        const accessToken = urlParams.get('access_token')
+        const idToken = urlParams.get('access_token')
         const refreshToken = urlParams.get('refresh_token')
-        if (accessToken && refreshToken) {
-            setLoginResponse({accessToken, refreshToken})
+        if (idToken && refreshToken) {
+            setLoginResponse({idToken, refreshToken})
         }
     })
 
@@ -110,10 +110,25 @@ export function App() {
                 },
                 credentials: 'include'
             });
-            if (credentialResponseResponse.redirected) {
-                window.location.href = credentialResponseResponse.url
+
+            console.log('credentialResponseResponse', credentialResponseResponse)
+
+            if (credentialResponseResponse.status > 400) {
+                const credentialResponseData = await credentialResponseResponse.text();
+                console.log('response to posted credential', credentialResponseData);
+                setError(credentialResponseData);
                 return
             }
+
+            if (credentialResponseResponse.status === 204) {
+                const uri = credentialResponseResponse.headers.get('Location')
+                if (uri !== null) {
+                    console.log('redirecting to', uri)
+                    window.location.href = uri
+                    return
+                }
+            }
+
             const credentialResponseData = await credentialResponseResponse.json();
             console.log('response to posted credential', credentialResponseData);
             setLoginResponse(credentialResponseData);            
@@ -179,12 +194,12 @@ export function App() {
                 <p>
                     <button onClick={startSession}>Login</button>
                 </p>
-                {loginResponse.accessToken !== '' && loginResponse.refreshToken !== '' && (
+                {loginResponse.idToken !== '' && loginResponse.refreshToken !== '' && (
                 <div>
-                    <p><a href={'https://jwt.io?token='+loginResponse.accessToken}>Inspect Access Token</a></p>
+                    <p><a href={'https://jwt.io?token='+loginResponse.idToken}>Inspect ID Token</a></p>
                     <p><a href={'https://jwt.io?token='+loginResponse.refreshToken}>Inspect Refresh Token</a></p>
                 </div>)}
-                {loginResponse.accessToken !== '' && loginResponse.refreshToken !== '' && (
+                {loginResponse.idToken !== '' && loginResponse.refreshToken !== '' && (
                     <p><button onClick={refresh}>Refresh</button></p>                
                 )}
                 <p>{error}</p>

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -98,14 +98,6 @@ session:
   # session key used to encrypt the session data, needs to be the same on all instances
   sessionKey: "0x${SESSION_SECRET}"
 
-# credential requirements
-# contains the credential requirements for the verifiers DID
-# if the user provides ANY of the listed credentials, the login is successful
-credentialRequirements:
-  - cTypeHash: "0x3291bb126e33b4862d421bfaa1d2f272e6cdfc4f96658988fbcffea8914bd9ac"
-    trustedAttesters: ["did:kilt:4pnfkRn5UurBJTW92d9TaVLR2CqJdY4z5HPjrEbpGyBykare"]
-    requiredProperties: ["Email"]
-
 # jwt config
 # contains the jwt config for the access and refresh tokens
 jwt:
@@ -123,9 +115,17 @@ wellKnownDid:
   keyUri: did:kilt:${AUTH_ACCOUNT_ADDRESS}#${ATTESTATION_KEY_ID}
   seed: "${ATTESTATION_SEED}"
 
-# oauth config
-oauth:
-  redirectUrls:
-    example-client:
-        - http://localhost:1606/callback.html
+# client configs
+clients:
+  example-client:
+    # credential requirements
+    # contains the credential requirements for the verifiers DID
+    # if the user provides ANY of the listed credentials, the login is successful
+    requirements:
+      - cTypeHash: "0x3291bb126e33b4862d421bfaa1d2f272e6cdfc4f96658988fbcffea8914bd9ac"
+        trustedAttesters: ["did:kilt:4pnfkRn5UurBJTW92d9TaVLR2CqJdY4z5HPjrEbpGyBykare"]
+        requiredProperties: ["Email"]
+    # valid redirect urls for this client
+    redirectUrls:
+      - http://localhost:1606/callback.html
 EOF

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,18 +11,17 @@ pub struct Config {
     pub host: String,
     pub port: u16,
     pub production: bool,
+    #[serde(rename = "kiltEndpoint")]
+    pub kilt_endpoint: Option<String>,
     #[serde(rename = "basePath")]
     pub base_path: String,
-    #[serde(rename = "credentialRequirements")]
-    pub credential_requirements: Vec<CredentialRequirement>,
     #[serde(rename = "session")]
     pub session_config: SessionConfig,
     #[serde(rename = "jwt")]
     pub jwt_config: JWTConfig,
     #[serde(rename = "wellKnownDid")]
     pub well_known_did_config: WellKnownDidConfig,
-    #[serde(rename = "oauth")]
-    pub oauth_config: Option<OauthConfig>,
+    pub clients: HashMap<String, ClientConfig>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -78,12 +77,19 @@ pub struct OauthConfig {
     pub redirect_urls: HashMap<String, Vec<String>>,
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ClientConfig {
+    pub requirements: Vec<CredentialRequirement>,
+    #[serde(rename = "redirectUrls")]
+    pub redirect_urls: Vec<String>,
+}
+
 impl Config {
     pub fn get_session_key(&self) -> Key {
         if self.session_config.session_key.len() >= 32 {
             Key::from(
                 hex::decode(self.session_config.session_key.trim_start_matches("0x"))
-                    .unwrap()
+                    .expect("session key is not a valid hex string")
                     .as_slice(),
             )
         } else {

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,0 +1,2 @@
+pub const OIDC_SESSION_KEY: &str = "oidc-context";
+pub const SESSION_COOKIE_NAME: &str = "sara";

--- a/src/jwt.rs
+++ b/src/jwt.rs
@@ -58,7 +58,7 @@ impl TokenFactory {
         }
     }
 
-    pub fn new_access_token(
+    pub fn new_id_token(
         &self,
         subject: &str,
         web3_name: &str,
@@ -166,7 +166,7 @@ mod tests {
         );
         let secret = "secret";
         let access_token =
-            token_builder.new_access_token("did:kilt:user", "user", &serde_json::Map::new(), &None);
+            token_builder.new_id_token("did:kilt:user", "user", &serde_json::Map::new(), &None);
         let jwt = access_token.to_jwt(secret).unwrap();
         println!("access_token {jwt}");
         let refresh_token = token_builder.new_refresh_token(

--- a/src/kilt/mod.rs
+++ b/src/kilt/mod.rs
@@ -1,4 +1,3 @@
-
 use sp_runtime::traits::{IdentifyAccount, Verify};
 
 use subxt::{config::polkadot::PolkadotExtrinsicParams, config::Config, OnlineClient};

--- a/src/routes/error.rs
+++ b/src/routes/error.rs
@@ -5,6 +5,7 @@ pub enum Error {
     OauthNotConfigured,
     OauthInvalidClientId,
     OauthInvalidRedirectUri,
+    OauthNoSession,
     SessionInsert,
     SessionGet,
     InvalidChallenge,
@@ -41,6 +42,7 @@ impl std::fmt::Display for Error {
             Error::GetChallenge => write!(f, "Failed to get challenge"),
             Error::VerifyCredential(ref s) => write!(f, "Failed to verify credential: {}", s),
             Error::CreateJWT => write!(f, "Failed to create JWT"),
+            Error::OauthNoSession => write!(f, "No session"),
         }
     }
 }
@@ -70,6 +72,7 @@ impl From<Error> for actix_web::Error {
             Error::SessionGet => actix_web::error::ErrorUnauthorized("Failed to get session"),
             Error::InvalidChallenge => actix_web::error::ErrorUnauthorized("Invalid challenge"),
             Error::InvalidNonce => actix_web::error::ErrorUnauthorized("Invalid nonce"),
+            Error::OauthNoSession => actix_web::error::ErrorUnauthorized("No session"),
             // default internal server error
             _ => actix_web::error::ErrorInternalServerError(e),
         }

--- a/src/routes/refresh.rs
+++ b/src/routes/refresh.rs
@@ -25,7 +25,7 @@ async fn refresh_handler(
     };
     let access_token = match app_state
         .token_builder
-        .new_access_token(&token.subject, &token.name, &token.properties, &token.nonce)
+        .new_id_token(&token.subject, &token.name, &token.properties, &token.nonce)
         .to_jwt(&app_state.token_secret)
     {
         Ok(token) => token,


### PR DESCRIPTION
This fixes various things to be compliant with openid connect core spec.

* returned token is now called id_token
* the final redirect contains the result parameters in the fragment part of the URL
* Count-intuitively the final redirect doesn't happen by sending a HTTP/302 redirect back. Instead a 204 is send back, but the location header is prepared exactly like it would be for a 302 response. The login page frontend sees this and executes the redirect to the location specified in the header. This is because suprisingly neither the fetch api nor the XHR requests would support this.


## Checklist:

- [ ] I have verified that the code works
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
    * Either PR or Ticket to update [the Docs](https://github.com/KILTprotocol/docs)
    * Link the PR/Ticket here
