### PR TITLE
fix: remove unnecessary steps & fix build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,18 +14,10 @@ config.yaml: setup-image
 delete-did: opendid-setup-image
 	podman run --rm -it -v $(shell pwd):/data -w /data --entrypoint /bin/bash $(SETUP_IMAGE) /app/scripts/delete-did.sh $(PAYMENT_SEED)
 
-binary: target/release/opendid
-target/release/opendid: $(shell find ./src -type f -name '*.rs')
-	cargo build --release
-
-
 main-image: .main-image
-.main-image: scripts/Containerfile target/release/opendid login-frontend/dist/index.html
+.main-image: scripts/Containerfile
 	podman build -t $(MAIN_IMAGE):latest -f scripts/Containerfile .
 	touch .main-image
-
-login-frontend/dist/index.html: $(shell find ./login-frontend/src -type f)
-	cd login-frontend && yarn && yarn build
 
 setup-image: .setup-image
 .setup-image: scripts/setup.Containerfile scripts/setup.sh
@@ -34,12 +26,9 @@ setup-image: .setup-image
 
 
 demo-image: .demo-image
-.demo-image: scripts/demo.Containerfile demo-project/index.js $(shell find ./demo-project/demo-frontend)
+.demo-image: scripts/demo.Containerfile
 	podman build -t $(DEMO_IMAGE):latest -f scripts/demo.Containerfile .
 	touch .demo-image
-
-demo-project/index.js: demo-project/main.ts 
-	cd demo-project && yarn && yarn build
 
 push-dev-images: .main-image .setup-image .demo-image
 	skopeo copy containers-storage:$(MAIN_IMAGE):latest docker://$(MAIN_IMAGE):dev

--- a/scripts/Containerfile
+++ b/scripts/Containerfile
@@ -1,14 +1,23 @@
-FROM rust:1.72-bookworm as builder
+FROM rust:1.72-bookworm as builder-rs
 WORKDIR /app
 RUN apt update && apt install protobuf-compiler -y
 COPY Cargo.toml Cargo.lock metadata.scale ./
 COPY src ./src
 RUN cargo build --release
 
+FROM node:alpine as builder-frontend
+
+WORKDIR /build
+COPY ./login-frontend /build
+RUN yarn && yarn build
+
 FROM docker.io/library/debian:stable-slim
+
 RUN apt update && apt install -y openssl ca-certificates libssl-dev
-COPY --from=builder /app/target/release/opendid /app/opendid
-COPY ./login-frontend/dist /srv
+
+COPY --from=builder-rs /app/target/release/opendid /app/opendid
+COPY --from=builder-frontend /build/dist /srv
+
 VOLUME /app/config.yaml
 
 CMD [ "/app/opendid", "--config", "/app/config.yaml"]

--- a/scripts/demo.Containerfile
+++ b/scripts/demo.Containerfile
@@ -1,9 +1,16 @@
+FROM node:alpine as builder
+WORKDIR /build
+
+COPY demo-project /build/
+
+RUN yarn && yarn build
+
 FROM node:alpine
 
 WORKDIR /srv
-COPY ./demo-project/package.json ./package.json
-COPY ./demo-project/node_modules ./node_modules
-COPY ./demo-project/index.js ./index.js
-COPY ./demo-project/demo-frontend ./demo-frontend
+COPY --from=builder /build/package.json ./package.json
+COPY --from=builder /build/node_modules ./node_modules
+COPY --from=builder /build/index.js ./index.js
+COPY --from=builder /build/demo-frontend ./demo-frontend
 
 ENTRYPOINT [ "/usr/local/bin/node", "/srv/index.js" ]


### PR DESCRIPTION
* no need to build the rust binary on the host? It's not used anywhere.
* don't build the js stuff outside the container. We have the containerised build so that you can build it without installing all the tools and so that you don't leak private info (like the name of your home folder in a rust build)