### PR TITLE
Improved Errors & Hide Serialization

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,8 +1,8 @@
 use std::collections::HashMap;
 
 use actix_web::cookie::Key;
-use hex::FromHexError;
 use serde::{Deserialize, Serialize};
+use sodiumoxide::crypto::box_::SecretKey;
 
 use crate::jwt::TokenFactory;
 
@@ -116,8 +116,9 @@ impl Config {
         }
     }
 
-    pub fn get_nacl_secret_key(&self) -> Result<Vec<u8>, FromHexError> {
-        hex::decode(self.session.nacl_secret_key.trim_start_matches("0x"))
+    pub fn get_nacl_secret_key(&self) -> anyhow::Result<SecretKey> {
+        let raw_key = hex::decode(self.session.nacl_secret_key.trim_start_matches("0x"))?;
+        SecretKey::from_slice(&raw_key).ok_or(anyhow::anyhow!("private key has invalid length"))
     }
 
     pub fn get_token_factory(&self) -> TokenFactory {

--- a/src/kilt/did_helper.rs
+++ b/src/kilt/did_helper.rs
@@ -51,11 +51,8 @@ pub async fn get_encryption_key_from_fulldid_key_uri(
 }
 
 pub async fn get_w3n(did: &str, cli: &OnlineClient<KiltConfig>) -> Result<String, Error> {
-    let account_id = match subxt::utils::AccountId32::from_str(did.trim_start_matches("did:kilt:"))
-    {
-        Ok(id) => id,
-        _ => return Err(Error::InvalidDid("Invalid DID")),
-    };
+    let account_id = subxt::utils::AccountId32::from_str(did.trim_start_matches("did:kilt:"))
+        .map_err(|_| Error::InvalidDid("Invalid DID"))?;
     let storage_key = kilt::storage().web3_names().names(account_id);
     let name = cli.storage().at_latest().await?.fetch(&storage_key).await?;
     if let Some(name) = name {

--- a/src/kilt/did_helper.rs
+++ b/src/kilt/did_helper.rs
@@ -81,21 +81,22 @@ struct LightDidDetails {
     e: LightDidKeyDetails,
 }
 
-pub fn parse_encryption_key_from_lightdid(did: &str) -> Result<Vec<u8>, Error> {
+pub fn parse_encryption_key_from_lightdid(did: &str) -> Result<box_::PublicKey, Error> {
     // example did:kilt:light:00${authAddress}:${details}#encryption
     log::debug!("key uri: {}", did);
     let mut parts = did.split('#');
-    let first = parts.next().ok_or(Error::InvalidDid("malformed"))?;
+    let first = parts.next().ok_or(Error::InvalidLightDid("malformed"))?;
     let mut parts = first.split(':').skip(4);
-    let details = parts.next().ok_or(Error::InvalidDid("malformed"))?;
+    let details = parts.next().ok_or(Error::InvalidLightDid("malformed"))?;
     log::debug!("details: {}", details);
     let mut chars = details.chars();
-    chars.next().ok_or(Error::InvalidDid("malformed"))?;
+    chars.next().ok_or(Error::InvalidLightDid("malformed"))?;
     let bs: Vec<u8> = FromBase58::from_base58(chars.as_str())
-        .map_err(|_| Error::InvalidDid("malformed base58"))?;
+        .map_err(|_| Error::InvalidLightDid("malformed base58"))?;
     let details: LightDidDetails =
-        serde_cbor::from_slice(&bs[1..]).map_err(|_| Error::InvalidDid("malformed cbor"))?;
-    Ok(details.e.public_key.to_vec())
+        serde_cbor::from_slice(&bs[1..]).map_err(|_| Error::InvalidLightDid("malformed cbor"))?;
+    box_::PublicKey::from_slice(&details.e.public_key)
+        .ok_or(Error::InvalidLightDid("Not a valid public key"))
 }
 
 pub async fn get_did_doc(

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ use anyhow::Context;
 use clap::Parser;
 
 use rhai_checker::RhaiCheckerMap;
+use sodiumoxide::crypto::box_;
 use well_known_did_config::create_well_known_did_config;
 
 mod cli;
@@ -26,9 +27,9 @@ mod kilt;
 mod messages;
 mod rhai_checker;
 mod routes;
+pub mod serialize;
 mod verify;
 mod well_known_did_config;
-pub mod serialize;
 
 use crate::{constants::SESSION_COOKIE_NAME, jwt::TokenFactory, routes::*};
 
@@ -37,7 +38,7 @@ use crate::{constants::SESSION_COOKIE_NAME, jwt::TokenFactory, routes::*};
 pub struct AppState {
     app_name: String,
     encryption_key_uri: String,
-    session_secret_key: Vec<u8>,
+    session_secret_key: box_::SecretKey,
     jwt_builder: TokenFactory,
     jwt_secret_key: String,
     jwt_public_key: Option<String>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,7 @@ mod rhai_checker;
 mod routes;
 mod verify;
 mod well_known_did_config;
+pub mod serialize;
 
 use crate::{constants::SESSION_COOKIE_NAME, jwt::TokenFactory, routes::*};
 

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -1,14 +1,15 @@
 use serde::{Deserialize, Serialize};
+use sodiumoxide::crypto::box_::Nonce;
 
-use crate::serialize::prefixed_hex;
+use crate::serialize::{hex_nonce, prefixed_hex};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct EncryptedMessage {
     #[serde(rename = "ciphertext")]
     #[serde(with = "prefixed_hex")]
     pub cipher_text: Vec<u8>,
-    #[serde(with = "prefixed_hex")]
-    pub nonce: Vec<u8>,
+    #[serde(with = "hex_nonce")]
+    pub nonce: Nonce,
     #[serde(rename = "receiverKeyUri")]
     pub receiver_key_uri: String,
     #[serde(rename = "senderKeyUri")]

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -1,10 +1,14 @@
 use serde::{Deserialize, Serialize};
 
+use crate::serialize::prefixed_hex;
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct EncryptedMessage {
     #[serde(rename = "ciphertext")]
-    pub cipher_text: String,
-    pub nonce: String,
+    #[serde(with = "prefixed_hex")]
+    pub cipher_text: Vec<u8>,
+    #[serde(with = "prefixed_hex")]
+    pub nonce: Vec<u8>,
     #[serde(rename = "receiverKeyUri")]
     pub receiver_key_uri: String,
     #[serde(rename = "senderKeyUri")]

--- a/src/routes/challenge.rs
+++ b/src/routes/challenge.rs
@@ -79,14 +79,11 @@ async fn challenge_response_handler(
         challenge_response.encryption_key_uri.as_str(),
     )?;
 
-    let our_secretkey = box_::SecretKey::from_slice(&app_state.session_secret_key)
-        .ok_or(Error::InvalidPrivateKey)?;
-
     let decrypted_challenge = box_::open(
         &challenge_response.encrypted_challenge,
         &challenge_response.nonce,
         &others_pubkey,
-        &our_secretkey,
+        &app_state.session_secret_key,
     )
     .map_err(|_| Error::InvalidChallenge("Unable to decrypt"))?;
 

--- a/src/routes/challenge.rs
+++ b/src/routes/challenge.rs
@@ -65,10 +65,11 @@ async fn challenge_response_handler(
 ) -> Result<HttpResponse, Error> {
     log::info!("POST challenge handler");
     let app_state = app_state.read()?;
-    let session_challenge = match session.get::<ChallengeData>("challenge")? {
-        Some(data) => data.challenge,
-        None => return Err(Error::SessionGet),
-    };
+    let session_challenge = session
+        .get::<ChallengeData>("challenge")?
+        .ok_or(Error::SessionGet)?
+        .challenge;
+
     let session_challenge_bytes = hex::decode(session_challenge.trim_start_matches("0x"))
         .map_err(|_| Error::InvalidChallenge("Challenge: Invalid Hex"))?;
     let nonce = hex::decode(challenge_response.nonce.trim_start_matches("0x"))

--- a/src/routes/challenge.rs
+++ b/src/routes/challenge.rs
@@ -81,14 +81,14 @@ async fn challenge_response_handler(
     .map_err(|_| Error::InvalidChallenge("Encrypted Challenge: Invalid Hex"))?;
     let others_pubkey = crate::kilt::parse_encryption_key_from_lightdid(
         challenge_response.encryption_key_uri.as_str(),
-    )
-    .map_err(|_| Error::InvalidLightDid)?;
-    let our_secretkey = app_state.session_secret_key.clone();
+    )?;
+
+    let our_secretkey = box_::SecretKey::from_slice(&app_state.session_secret_key)
+        .ok_or(Error::InvalidPrivateKey)?;
     let nonce = box_::Nonce::from_slice(&nonce).ok_or(Error::InvalidNonce)?;
-    let pk = box_::PublicKey::from_slice(&others_pubkey).ok_or(Error::InvalidLightDid)?;
-    let sk = box_::SecretKey::from_slice(&our_secretkey).ok_or(Error::InvalidPrivateKey)?;
-    let decrypted_challenge = box_::open(&encrypted_challenge, &nonce, &pk, &sk)
-        .map_err(|_| Error::InvalidChallenge("Unable to decrypt"))?;
+    let decrypted_challenge =
+        box_::open(&encrypted_challenge, &nonce, &others_pubkey, &our_secretkey)
+            .map_err(|_| Error::InvalidChallenge("Unable to decrypt"))?;
     if session_challenge_bytes == decrypted_challenge {
         session
             .insert("key_uri", challenge_response.encryption_key_uri.clone())

--- a/src/routes/credentials.rs
+++ b/src/routes/credentials.rs
@@ -115,11 +115,10 @@ async fn get_credential_requirements_handler(
     let msg_bytes = msg_json.as_bytes();
     let our_secretkey = app_state.session_secret_key.clone();
     let others_pubkey =
-        parse_encryption_key_from_lightdid(key_uri.as_str()).map_err(|_| Error::InvalidLightDid)?;
+        parse_encryption_key_from_lightdid(key_uri.as_str())?;
     let nonce = box_::gen_nonce();
-    let pk = box_::PublicKey::from_slice(&others_pubkey).ok_or(Error::InvalidLightDid)?;
     let sk = box_::SecretKey::from_slice(&our_secretkey).ok_or(Error::InvalidPrivateKey)?;
-    let encrypted_msg = box_::seal(msg_bytes, &nonce, &pk, &sk);
+    let encrypted_msg = box_::seal(msg_bytes, &nonce, &others_pubkey, &sk);
     let encrypted_msg_hex = format!("0x{}", hex::encode(encrypted_msg));
     let nonce_hex = format!("0x{}", hex::encode(nonce));
     let response = EncryptedMessage {

--- a/src/routes/credentials.rs
+++ b/src/routes/credentials.rs
@@ -216,10 +216,15 @@ async fn post_credential_handler(
                 continue;
             }
             let mut properties_fulfilled = true;
-            let content_object = match content.claim.contents.as_object() {
-                Some(data) => data,
-                _ => return Ok(HttpResponse::BadRequest().body("Could not get claim contents")),
-            };
+            let content_object =
+                content
+                    .claim
+                    .contents
+                    .as_object()
+                    .ok_or(Error::VerifyCredential(
+                        "Could not get claim contents".into(),
+                    ))?;
+
             for property in &requirement.required_properties {
                 if !content_object.contains_key(property) {
                     log::info!("Requirement property '{}' not found", property);

--- a/src/routes/credentials.rs
+++ b/src/routes/credentials.rs
@@ -114,8 +114,7 @@ async fn get_credential_requirements_handler(
     let msg_json = serde_json::to_string(&msg).unwrap();
     let msg_bytes = msg_json.as_bytes();
     let our_secretkey = app_state.session_secret_key.clone();
-    let others_pubkey =
-        parse_encryption_key_from_lightdid(key_uri.as_str())?;
+    let others_pubkey = parse_encryption_key_from_lightdid(key_uri.as_str())?;
     let nonce = box_::gen_nonce();
     let sk = box_::SecretKey::from_slice(&our_secretkey).ok_or(Error::InvalidPrivateKey)?;
     let encrypted_msg = box_::seal(msg_bytes, &nonce, &others_pubkey, &sk);

--- a/src/routes/error.rs
+++ b/src/routes/error.rs
@@ -11,7 +11,6 @@ pub enum Error {
     InvalidChallenge(&'static str),
     InvalidNonce,
     InvalidLightDid(&'static str),
-    InvalidPrivateKey,
     CantConnectToBlockchain,
     InvalidDid(&'static str),
     FailedToDecrypt,
@@ -36,7 +35,6 @@ impl std::fmt::Display for Error {
             Error::InvalidChallenge(s) => write!(f, "Invalid challenge: {}", s),
             Error::InvalidNonce => write!(f, "Invalid nonce"),
             Error::InvalidLightDid(s) => write!(f, "Invalid light DID: {}", s),
-            Error::InvalidPrivateKey => write!(f, "Invalid private key"),
             Error::CantConnectToBlockchain => write!(f, "Can't connect to KILT blockchain"),
             Error::InvalidDid(s) => write!(f, "Invalid DID: {}", s),
             Error::FailedToDecrypt => write!(f, "Failed to decrypt"),
@@ -71,7 +69,6 @@ impl From<Error> for actix_web::Error {
             | Error::OauthNoSession => actix_web::error::ErrorUnauthorized(e),
             // Internal errors. we don't pass the error message to the frontend to not leak information.
             Error::SessionInsert
-            | Error::InvalidPrivateKey
             | Error::CantConnectToBlockchain
             | Error::CreateJWT
             | Error::Internal(_)

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -23,3 +23,27 @@ pub mod prefixed_hex {
         s.serialize_str(&format!("0x{}", hex))
     }
 }
+
+/// Serialize and deserialize `0x` prefixed hex strings to and from Vec<u8>.
+pub mod hex_nonce {
+    use sodiumoxide::crypto::box_::Nonce;
+
+    use super::*;
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Nonce, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s: &str = Deserialize::deserialize(deserializer)?;
+        let bytes = hex::decode(s.trim_start_matches("0x")).map_err(Error::custom)?;
+        Nonce::from_slice(&bytes).ok_or_else(|| Error::custom("invalid nonce length"))
+    }
+
+    pub fn serialize<S>(value: &Nonce, s: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let hex = hex::encode(value);
+        s.serialize_str(&format!("0x{}", hex))
+    }
+}

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -1,0 +1,25 @@
+use serde::de::Error;
+use serde::Deserialize;
+use serde::{Deserializer, Serializer};
+
+/// Serialize and deserialize `0x` prefixed hex strings to and from Vec<u8>.
+pub mod prefixed_hex {
+
+    use super::*;
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s: &str = Deserialize::deserialize(deserializer)?;
+        hex::decode(s.trim_start_matches("0x")).map_err(Error::custom)
+    }
+
+    pub fn serialize<S>(value: &Vec<u8>, s: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let hex = hex::encode(value);
+        s.serialize_str(&format!("0x{}", hex))
+    }
+}

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -120,9 +120,9 @@ pub async fn check_signature(
     challenge: &Vec<u8>,
     cli: &OnlineClient<KiltConfig>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    log::info!("Checking signature");
+    log::trace!("Checking signature");
     for content in msg.body.content.iter() {
-        log::info!("Checking signature for claim: {:#?}", content);
+        log::trace!("Checking signature for claim: {:#?}", content);
         // get the public key from the chain
         let did = content.claim.owner.clone();
         let public_key = get_auth_pubkey(&did, cli).await?;
@@ -170,13 +170,13 @@ async fn check_attestation(
     let mut attestations = Vec::new();
     for content in msg.body.content.iter() {
         let attestation = get_attestation(&content.root_hash, cli).await?;
-        log::info!("Attestation found on chain: {:?}", attestation);
+        log::trace!("Attestation found on chain: {:?}", attestation);
 
         // check if it is  not revoked
         if attestation.revoked {
             return Err("Attestation is revoked".into());
         }
-        log::info!("Attestation not revoked");
+        log::trace!("Attestation not revoked");
         attestations.push(attestation);
     }
     Ok(attestations)
@@ -188,13 +188,13 @@ pub async fn verify_credential_message(
     cli: &OnlineClient<KiltConfig>,
 ) -> Result<Vec<AttestationDetails>, Box<dyn std::error::Error>> {
     check_claim_contents(msg)?;
-    log::info!("Claim contents verified");
+    log::trace!("Claim contents verified");
     check_root_hash(msg)?;
-    log::info!("Root hash verified");
+    log::trace!("Root hash verified");
     check_signature(msg, &challenge, cli).await?;
-    log::info!("Claimer signature verified");
+    log::trace!("Claimer signature verified");
     let attestations = check_attestation(msg, cli).await?;
-    log::info!("Attestation verified");
+    log::trace!("Attestation verified");
     Ok(attestations)
 }
 


### PR DESCRIPTION
## related https://github.com/KILTprotocol/ticket/issues/2967

* when parsing the encryption key, return the actually key instead of raw bytes
* list all errors explicitly so that no error is marked internal by accident
* 