### PR TITLE
fix: env variables

### DIFF
--- a/login-frontend/src/App.tsx
+++ b/login-frontend/src/App.tsx
@@ -95,6 +95,7 @@ export function App() {
       const kid = `${did}${didDocument?.document?.authentication[0].id}`;
       const kty = didDocument?.document?.authentication[0].type;
 
+      // Not completely standard, but SR25519 is not commonly used for JWTs.
       const header = { alg: 'EdDSA', typ: 'JWT', crv: 'Ed25519', kid, kty };
       const body = { iss: did, sub: did, nonce, exp, nbf };
 

--- a/login-frontend/src/App.tsx
+++ b/login-frontend/src/App.tsx
@@ -114,21 +114,16 @@ export function App() {
     const url = `/api/v1/did/${token}`;
     const response = await fetch(url, { method: 'POST' });
 
-    if (response.status >= 400) {
+    if (response.status !== 204) {
       const responseData = await response.text();
       throw new Error(responseData);
     }
 
-    if (response.status === 204) {
-      const uri = response.headers.get('Location');
-      if (uri !== null) {
-        window.location.href = uri;
-        return;
-      }
+    const uri = response.headers.get('Location');
+    if (uri !== null) {
+      window.location.href = uri;
+      return;
     }
-
-    const responseData = await response.text();
-    throw new Error(responseData);
   };
 
   const handleSIOPV2Login = useCallback(

--- a/login-frontend/src/App.tsx
+++ b/login-frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import { FormEvent, useCallback, useEffect, useState } from 'react';
-import { Did, connect } from '@kiltprotocol/sdk-js';
+import { Did, DidResolutionResult, DidUri, connect } from '@kiltprotocol/sdk-js';
 import * as sha512 from 'js-sha512';
 
 import './App.css';
@@ -76,62 +76,82 @@ export function App() {
     [kilt],
   );
 
-  const handleSIOPV2Login = useCallback(
-    async (nonce: string, event: FormEvent<HTMLFormElement>) => {
-      connect(process.env.WSS_ENDPOINT ? process.env.WSS_ENDPOINT : 'wss://peregrine.kilt.io');
+  const fetchWssEndpoint = async (): Promise<string> => {
+    const endpointURL = '/api/v1/endpoint';
+    const response = await fetch(endpointURL, { method: 'get' });
 
-      const form = event.currentTarget;
-      const extension = new FormData(form).get('extension') as string;
-      const Dids = await kilt[extension].getDidList();
+    if (response.status !== 200) {
+      const responseData = await response.text();
+      throw new Error(responseData);
+    }
 
-      const did = Dids[0].did;
+    return response.json();
+  };
 
-      const didDocument = await Did.resolve(did);
-
-      // jwt parts
+  const getJwtToken = useCallback(
+    async (did: DidUri, didDocument: DidResolutionResult, nonce: string, extension: string): Promise<string> => {
       const nbf = Math.floor(Date.now() / 1000);
       const exp = nbf + 60;
       const kid = `${did}${didDocument?.document?.authentication[0].id}`;
       const kty = didDocument?.document?.authentication[0].type;
-      // Not completely standard, but SR25519 is not commonly used for JWTs.
+
       const header = { alg: 'EdDSA', typ: 'JWT', crv: 'Ed25519', kid, kty };
       const body = { iss: did, sub: did, nonce, exp, nbf };
 
-      //encoded + signature
       const headerEncoded = btoa(JSON.stringify(header));
       const bodyEncoded = btoa(JSON.stringify(body));
       const dataToSign = headerEncoded + '.' + bodyEncoded;
 
       const signData = await kilt[extension].signWithDid(sha512.sha512(dataToSign), did);
 
-      // submit token
-      const token = dataToSign + '.' + btoa(signData.signature);
-
-      const url = `/api/v1/did/${token}`;
-
-      const didLoginResponse = await fetch(url, {
-        method: 'POST',
-      });
-
-      if (didLoginResponse.status >= 400) {
-        const credentialResponseData = await didLoginResponse.text();
-        throw new Error(credentialResponseData);
-      }
-
-      if (didLoginResponse.status === 204) {
-        const uri = didLoginResponse.headers.get('Location');
-        if (uri !== null) {
-          window.location.href = uri;
-          return;
-        }
-      }
-
-      const response = await didLoginResponse.text();
-      throw new Error(response);
+      return dataToSign + '.' + btoa(signData.signature);
     },
     [kilt],
   );
 
+  const submitToken = async (token: string): Promise<void> => {
+    const url = `/api/v1/did/${token}`;
+    const response = await fetch(url, { method: 'POST' });
+
+    if (response.status >= 400) {
+      const responseData = await response.text();
+      throw new Error(responseData);
+    }
+
+    if (response.status === 204) {
+      const uri = response.headers.get('Location');
+      if (uri !== null) {
+        window.location.href = uri;
+        return;
+      }
+    }
+
+    const responseData = await response.text();
+    throw new Error(responseData);
+  };
+
+  const handleSIOPV2Login = useCallback(
+    async (nonce: string, event: FormEvent<HTMLFormElement>) => {
+      const form = event.currentTarget;
+      const extension = new FormData(form).get('extension') as string;
+
+      const wssEndpoint = await fetchWssEndpoint();
+      connect(wssEndpoint);
+
+      const Dids = await kilt[extension].getDidList();
+      const did = Dids[0].did;
+      const didDocument = await Did.resolve(did);
+
+      if (!didDocument) {
+        throw new Error('Did Document is null');
+      }
+
+      const token = await getJwtToken(did, didDocument, nonce, extension);
+
+      await submitToken(token);
+    },
+    [kilt, getJwtToken],
+  );
   const handleLogin = useCallback(
     async (event: FormEvent<HTMLFormElement>) => {
       event.preventDefault();

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,7 +12,7 @@ pub struct Config {
     pub host: String,
     pub port: u16,
     pub production: bool,
-    pub kilt_endpoint: Option<String>,
+    kilt_endpoint: Option<String>,
     pub base_path: String,
     pub session: SessionConfig,
     pub jwt: JWTConfig,
@@ -134,5 +134,16 @@ impl Config {
 
     pub fn get_session_ttl(&self) -> i64 {
         self.session.session_ttl
+    }
+
+    pub fn get_endpoint_url(&self) -> String {
+        match &self.kilt_endpoint {
+            Some(e) => match e.as_str() {
+                "spiritnet" => "wss://spiritnet.kilt.io:443".to_string(),
+                "peregrine" => "wss://peregrine.kilt.io:443/parachain-public-ws".to_string(),
+                _ => e.clone(),
+            },
+            None => "wss://peregrine.kilt.io:443/parachain-public-ws".to_string(),
+        }
     }
 }

--- a/src/kilt/mod.rs
+++ b/src/kilt/mod.rs
@@ -1,8 +1,6 @@
 use sp_runtime::traits::{IdentifyAccount, Verify};
 use subxt::{config::polkadot::PolkadotExtrinsicParams, config::Config, OnlineClient};
 
-use crate::utils::get_endpoint_url;
-
 #[cfg(feature = "peregrine")]
 #[subxt::subxt(runtime_metadata_path = "./metadata-peregrine-11110.scale")]
 pub mod kilt {}
@@ -31,8 +29,7 @@ impl Config for KiltConfig {
 }
 
 pub async fn connect(
-    endpoint: &str,
+    endpoint_url: &str,
 ) -> Result<OnlineClient<KiltConfig>, Box<dyn std::error::Error>> {
-    let endpoint_url = get_endpoint_url(endpoint);
     Ok(OnlineClient::<KiltConfig>::from_url(endpoint_url).await?)
 }

--- a/src/kilt/mod.rs
+++ b/src/kilt/mod.rs
@@ -1,6 +1,7 @@
 use sp_runtime::traits::{IdentifyAccount, Verify};
-
 use subxt::{config::polkadot::PolkadotExtrinsicParams, config::Config, OnlineClient};
+
+use crate::utils::get_endpoint_url;
 
 #[cfg(feature = "peregrine")]
 #[subxt::subxt(runtime_metadata_path = "./metadata-peregrine-11110.scale")]
@@ -32,10 +33,6 @@ impl Config for KiltConfig {
 pub async fn connect(
     endpoint: &str,
 ) -> Result<OnlineClient<KiltConfig>, Box<dyn std::error::Error>> {
-    let endpoint_url = match endpoint {
-        "spiritnet" => "wss://spiritnet.kilt.io:443",
-        "peregrine" => "wss://peregrine.kilt.io:443/parachain-public-ws",
-        _ => endpoint,
-    };
+    let endpoint_url = get_endpoint_url(endpoint);
     Ok(OnlineClient::<KiltConfig>::from_url(endpoint_url).await?)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,7 @@ mod messages;
 mod rhai_checker;
 mod routes;
 pub mod serialize;
-pub mod utils;
+mod utils;
 mod verify;
 mod well_known_did_config;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,6 @@ mod messages;
 mod rhai_checker;
 mod routes;
 pub mod serialize;
-mod utils;
 mod verify;
 mod well_known_did_config;
 
@@ -69,10 +68,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         jwt_algorithm: config.jwt.algorithm.to_string(),
         well_known_did_config: create_well_known_did_config(&config.well_known_did_config)
             .context("Error creating well-known DID configuration")?,
-        kilt_endpoint: config
-            .kilt_endpoint
-            .clone()
-            .unwrap_or("spiritnet".to_string()),
+        kilt_endpoint: config.get_endpoint_url(),
         client_configs: config.clients.clone(),
         rhai_checkers: RhaiCheckerMap::new(),
     }));

--- a/src/main.rs
+++ b/src/main.rs
@@ -125,6 +125,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .service(well_known_did_config_handler)
             .service(login_with_did)
             .service(authorize_handler)
+            .service(get_endpoint)
             .service(actix_files::Files::new("/", &config.base_path).index_file("index.html"))
     })
     .bind((host.as_str(), port))?

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,7 @@ mod messages;
 mod rhai_checker;
 mod routes;
 pub mod serialize;
+pub mod utils;
 mod verify;
 mod well_known_did_config;
 

--- a/src/routes/endpoint.rs
+++ b/src/routes/endpoint.rs
@@ -2,11 +2,11 @@ use std::sync::RwLock;
 
 use actix_web::{get, web, HttpResponse};
 
-use crate::{routes::error::Error, utils::get_endpoint_url, AppState};
+use crate::{routes::error::Error, AppState};
 
 #[get("/api/v1/endpoint")]
 async fn get_endpoint(app_state: web::Data<RwLock<AppState>>) -> Result<HttpResponse, Error> {
     let app_state = app_state.read()?;
-    let endpoint_url = get_endpoint_url(&app_state.kilt_endpoint);
+    let endpoint_url = app_state.kilt_endpoint.clone();
     Ok(HttpResponse::Ok().json(endpoint_url))
 }

--- a/src/routes/endpoint.rs
+++ b/src/routes/endpoint.rs
@@ -2,14 +2,11 @@ use std::sync::RwLock;
 
 use actix_web::{get, web, HttpResponse};
 
-use crate::{routes::error::Error, AppState};
+use crate::{routes::error::Error, utils::get_endpoint_url, AppState};
 
 #[get("/api/v1/endpoint")]
 async fn get_endpoint(app_state: web::Data<RwLock<AppState>>) -> Result<HttpResponse, Error> {
     let app_state = app_state.read()?;
-    let endpoint = match app_state.kilt_endpoint.as_str() {
-        "spiritnet" => "wss://kilt-rpc.dwellir.com",
-        _ => "wss://peregrine.kilt.io",
-    };
-    Ok(HttpResponse::Ok().json(endpoint))
+    let endpoint_url = get_endpoint_url(&app_state.kilt_endpoint);
+    Ok(HttpResponse::Ok().json(endpoint_url))
 }

--- a/src/routes/endpoint.rs
+++ b/src/routes/endpoint.rs
@@ -1,0 +1,15 @@
+use std::sync::RwLock;
+
+use actix_web::{get, web, HttpResponse};
+
+use crate::{routes::error::Error, AppState};
+
+#[get("/api/v1/endpoint")]
+async fn get_endpoint(app_state: web::Data<RwLock<AppState>>) -> Result<HttpResponse, Error> {
+    let app_state = app_state.read()?;
+    let endpoint = match app_state.kilt_endpoint.as_str() {
+        "spiritnet" => "wss://kilt-rpc.dwellir.com",
+        _ => "wss://peregrine.kilt.io",
+    };
+    Ok(HttpResponse::Ok().json(endpoint))
+}

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -2,6 +2,7 @@ mod authorize;
 mod challenge;
 mod credentials;
 mod did;
+mod endpoint;
 mod refresh;
 mod well_known_did_config;
 
@@ -10,5 +11,6 @@ pub use authorize::*;
 pub use challenge::*;
 pub use credentials::*;
 pub use did::*;
+pub use endpoint::*;
 pub use refresh::*;
 pub use well_known_did_config::*;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,7 @@
+pub fn get_endpoint_url(endpoint: &str) -> &str {
+    match endpoint {
+        "spiritnet" => "wss://spiritnet.kilt.io:443",
+        "peregrine" => "wss://peregrine.kilt.io:443/parachain-public-ws",
+        _ => endpoint,
+    }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,7 +1,0 @@
-pub fn get_endpoint_url(endpoint: &str) -> &str {
-    match endpoint {
-        "spiritnet" => "wss://spiritnet.kilt.io:443",
-        "peregrine" => "wss://peregrine.kilt.io:443/parachain-public-ws",
-        _ => endpoint,
-    }
-}


### PR DESCRIPTION
## fixes KILTProtocol/ticket#3076
The environment variables for OpenDID were only utilized during the build process, resulting in the use of default values specified in the code. While OpenDID should be able to run on Spiritnet, the environment variables need to be configurable.  

To address this issue, Parcel is replaced with react-scripts. This change is made because Parcel lacks real configuration tools to adjust bundled files. The config.js file in the public folder was bundled into a different file, making it challenging to substitute.

With the new approach, the environment variables are stored in a config.js file. It is now possible to configure them using different orchestration software such as k8s or Docker Compose. A different configuration file can now be mounted into the dist folder.

 
 