### PR TITLE
fix: container file

### DIFF
--- a/scripts/Containerfile
+++ b/scripts/Containerfile
@@ -1,7 +1,7 @@
 FROM rust:1.72-bookworm as builder-rs
 WORKDIR /app
 RUN apt update && apt install protobuf-compiler -y
-COPY Cargo.toml Cargo.lock metadata.scale ./
+COPY Cargo.toml Cargo.lock metadata-peregrine-11110.scale metadata-spiritnet-11110.scale ./
 COPY src ./src
 RUN cargo build --release
 


### PR DESCRIPTION
## fixes CI
The metadata is renamed to the different runtimes.
