### PR TITLE
Use Tokio Runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2931,6 +2931,7 @@ dependencies = [
  "sp-core",
  "sp-runtime",
  "subxt",
+ "tokio",
  "uuid",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+
 authors = ["KILT <info@kilt.io>"]
 edition = "2021"
 name = "opendid"
@@ -7,41 +8,42 @@ version = "0.1.0"
 [dependencies]
 actix-cors = "0.6.4"
 actix-files = "0.6.2"
-actix-session = {version = "0.7", features = ["cookie-session"]}
+actix-session = { version = "0.7", features = ["cookie-session"] }
 actix-web = "4"
 anyhow = "1.0.75"
 base58 = "0.2.0"
 base64 = "0.21.2"
 blake2 = "0.10.6"
-chrono = {version = "0.4.26", features = ["serde"]}
-clap = {version = "4.3.5", features = ["derive", "env"]}
+chrono = { version = "0.4.26", features = ["serde"] }
+clap = { version = "4.3.5", features = ["derive", "env"] }
 clap-verbosity-flag = "2.0.1"
 env_logger = "0.10.0"
-etcd-client = {version = "0.11.1", features = ["tls"]}
+etcd-client = { version = "0.11.1", features = ["tls"] }
 hex = "0.4.3"
 hmac = "0.12.1"
-jwt = {version = "0.16.0", features = ["openssl"]}
+jwt = { version = "0.16.0", features = ["openssl"] }
 lazy_static = "1.4.0"
 log = "0.4.19"
 once_cell = "1.18.0"
 openssl = "0.10.57"
 rand = "0.8.5"
-rhai = {version = "1.15.1", features = ["serde", "sync"]}
-schnorrkel = {version = "0.10.2", features = [
-  "preaudit_deprecated",
-  "u64_backend",
-], default-features = false}
-serde = {version = "1.0.164", features = ["derive"]}
+rhai = { version = "1.15.1", features = ["serde", "sync"] }
+schnorrkel = { version = "0.10.2", features = [
+    "preaudit_deprecated",
+    "u64_backend",
+], default-features = false }
+serde = { version = "1.0.164", features = ["derive"] }
 serde_cbor = "0.11.2"
 serde_json = "1.0.97"
 serde_with = "3.0.0"
 serde_yaml = "0.9.21"
 sha2 = "0.10.7"
 sodiumoxide = "0.2.7"
-sp-core = {version = "21.0.0", default-features = false}
+sp-core = { version = "21.0.0", default-features = false }
 sp-runtime = "24.0.0"
 subxt = "0.31.0"
-uuid = {version = "1.3.4", features = ["v4"]}
+tokio = { version = "1.9.0", features = ["rt-multi-thread"] }
+uuid = { version = "1.3.4", features = ["v4"] }
 
 [features]
 default = []

--- a/src/config_updater.rs
+++ b/src/config_updater.rs
@@ -1,6 +1,6 @@
 use crate::{config::EtcdConfig, routes::error::Error, AppState};
 use actix_web::web;
-use std::sync::RwLock;
+use tokio::sync::RwLock;
 
 // ConfigUpdater is responsible for fetching client configurations from etcd and
 // updating the app state with the latest configurations.
@@ -48,7 +48,7 @@ impl ConfigUpdater {
     pub async fn read_initial_config(&mut self) -> Result<(), Box<dyn std::error::Error + '_>> {
         // we start from the client configs in the current app state
         let mut client_configs = {
-            let app_state = self.app_state.read()?;
+            let app_state = self.app_state.read().await;
             app_state.client_configs.clone()
         };
 
@@ -73,7 +73,7 @@ impl ConfigUpdater {
             client_configs.insert(client_id, client_config);
         }
 
-        self.app_state.write()?.client_configs = client_configs;
+        self.app_state.write().await.client_configs = client_configs;
 
         Ok(())
     }
@@ -82,7 +82,7 @@ impl ConfigUpdater {
     pub async fn watch_for_updates(&mut self) -> Result<(), Box<dyn std::error::Error + '_>> {
         // we start from the client configs in the current app state
         let mut client_configs = {
-            let app_state = self.app_state.read()?;
+            let app_state = self.app_state.read().await;
             app_state.client_configs.clone()
         };
 
@@ -126,7 +126,7 @@ impl ConfigUpdater {
             }
 
             // we update the app state with the latest client configs
-            let mut app_state = self.app_state.write()?;
+            let mut app_state = self.app_state.write().await;
             app_state.client_configs = client_configs.clone();
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, sync::RwLock};
+use std::collections::HashMap;
 
 use actix_cors::Cors;
 use actix_session::{
@@ -16,6 +16,7 @@ use clap::Parser;
 
 use rhai_checker::RhaiCheckerMap;
 use sodiumoxide::crypto::box_;
+use tokio::sync::RwLock;
 use well_known_did_config::create_well_known_did_config;
 
 mod cli;
@@ -49,7 +50,7 @@ pub struct AppState {
     rhai_checkers: RhaiCheckerMap,
 }
 
-#[actix_web::main]
+#[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli = cli::Cli::parse();
     env_logger::Builder::new()

--- a/src/routes/authorize.rs
+++ b/src/routes/authorize.rs
@@ -1,8 +1,7 @@
-use std::sync::RwLock;
-
 use actix_session::Session;
 use actix_web::{get, web, HttpResponse};
 use serde::{Deserialize, Serialize};
+use tokio::sync::RwLock;
 
 use crate::{constants::OIDC_SESSION_KEY, routes::error::Error, AppState};
 
@@ -25,7 +24,7 @@ async fn authorize_handler(
     query: web::Query<AuthorizeQueryParameters>,
 ) -> Result<HttpResponse, Error> {
     log::info!("GET authorize handler");
-    let app_state = app_state.read()?;
+    let app_state = app_state.read().await;
     let redirect_urls = &app_state
         .client_configs
         .get(&query.client_id)

--- a/src/routes/challenge.rs
+++ b/src/routes/challenge.rs
@@ -1,5 +1,3 @@
-use std::sync::RwLock;
-
 use actix_session::Session;
 use actix_web::{get, post, web, HttpResponse};
 
@@ -7,6 +5,7 @@ use rand::Rng;
 use serde::{Deserialize, Serialize};
 
 use sodiumoxide::crypto::box_;
+use tokio::sync::RwLock;
 
 use crate::{
     routes::error::Error,
@@ -55,7 +54,7 @@ async fn challenge_handler(
     app_state: web::Data<RwLock<AppState>>,
 ) -> Result<HttpResponse, Error> {
     log::info!("GET challenge handler");
-    let app_state = app_state.read()?;
+    let app_state = app_state.read().await;
     let challenge_data = ChallengeData::new(&app_state.app_name, &app_state.encryption_key_uri);
     session.insert("challenge", challenge_data.clone())?;
     Ok(HttpResponse::Ok().json(challenge_data))
@@ -69,7 +68,7 @@ async fn challenge_response_handler(
     challenge_response: web::Json<ChallengeResponse>,
 ) -> Result<HttpResponse, Error> {
     log::info!("POST challenge handler");
-    let app_state = app_state.read()?;
+    let app_state = app_state.read().await;
     let session_challenge_bytes = session
         .get::<ChallengeData>("challenge")?
         .ok_or(Error::SessionGet)?

--- a/src/routes/did.rs
+++ b/src/routes/did.rs
@@ -3,8 +3,8 @@ use actix_web::{post, web, HttpResponse};
 use base64::{engine::general_purpose, Engine};
 use sha2::{Digest, Sha512};
 use sp_runtime::traits::Verify;
-use std::sync::RwLock;
 use subxt::ext::codec::{Decode, IoReader};
+use tokio::sync::RwLock;
 
 use crate::{
     constants::OIDC_SESSION_KEY,
@@ -112,7 +112,7 @@ async fn login_with_did(
     let sender = &jwt_payload.iss;
 
     let endpoint = {
-        let app_state = app_state.read()?;
+        let app_state = app_state.read().await;
         app_state.kilt_endpoint.clone()
     };
     let cli = kilt::connect(&endpoint)
@@ -179,7 +179,7 @@ async fn login_with_did(
 
     //construct id_token and refresh_token
 
-    let mut app_state = app_state.write()?; // may update the rhai checkers
+    let mut app_state = app_state.write().await; // may update the rhai checkers
     let id_token = app_state
         .jwt_builder
         .new_id_token(sender, &w3n, &props, &Some(nonce.clone()))

--- a/src/routes/endpoint.rs
+++ b/src/routes/endpoint.rs
@@ -1,12 +1,11 @@
-use std::sync::RwLock;
-
 use actix_web::{get, web, HttpResponse};
+use tokio::sync::RwLock;
 
 use crate::{routes::error::Error, AppState};
 
 #[get("/api/v1/endpoint")]
 async fn get_endpoint(app_state: web::Data<RwLock<AppState>>) -> Result<HttpResponse, Error> {
-    let app_state = app_state.read()?;
+    let app_state = app_state.read().await;
     let endpoint_url = app_state.kilt_endpoint.clone();
     Ok(HttpResponse::Ok().json(endpoint_url))
 }

--- a/src/routes/error.rs
+++ b/src/routes/error.rs
@@ -18,7 +18,6 @@ pub enum Error {
     GetChallenge,
     VerifyCredential(String),
     CreateJWT,
-    LockPoison,
     Internal(String),
     VerifyJWT(String),
     InvalidDidSignature,
@@ -45,7 +44,6 @@ impl std::fmt::Display for Error {
             Error::VerifyCredential(s) => write!(f, "Failed to verify credential: {}", s),
             Error::CreateJWT => write!(f, "Failed to create JWT"),
             Error::OauthNoSession => write!(f, "No session"),
-            Error::LockPoison => write!(f, "Lock poison"),
             Error::VerifyJWT(s) => write!(f, "Failed to verify JWT {} ", s),
             Error::InvalidDidSignature => write!(f, "Failed to verify DID Signature"),
             Error::Internal(s) => write!(f, "Internal error: {}", s),
@@ -77,8 +75,7 @@ impl From<Error> for actix_web::Error {
             Error::SessionInsert
             | Error::CantConnectToBlockchain
             | Error::CreateJWT
-            | Error::Internal(_)
-            | Error::LockPoison => {
+            | Error::Internal(_) => {
                 log::error!("Internal Error: {}", e);
                 actix_web::error::ErrorInternalServerError("Internal Error")
             }
@@ -95,12 +92,6 @@ impl From<SessionInsertError> for Error {
 impl From<SessionGetError> for Error {
     fn from(_: SessionGetError) -> Self {
         Error::SessionGet
-    }
-}
-
-impl<T> From<std::sync::PoisonError<T>> for Error {
-    fn from(_: std::sync::PoisonError<T>) -> Self {
-        Error::LockPoison
     }
 }
 

--- a/src/routes/well_known_did_config.rs
+++ b/src/routes/well_known_did_config.rs
@@ -1,6 +1,5 @@
-use std::sync::RwLock;
-
 use actix_web::{get, web, HttpResponse};
+use tokio::sync::RwLock;
 
 use crate::{routes::error::Error, AppState};
 
@@ -8,6 +7,6 @@ use crate::{routes::error::Error, AppState};
 async fn well_known_did_config_handler(
     app_state: web::Data<RwLock<AppState>>,
 ) -> Result<HttpResponse, Error> {
-    let app_state = app_state.read()?;
+    let app_state = app_state.read().await;
     Ok(HttpResponse::Ok().json(&app_state.well_known_did_config))
 }


### PR DESCRIPTION
Use the tokio runtime in order to use tokio's `RwLock` which provides better performance in the async context, resulting in overall better RPS. 

