### PR TITLE
Fix Setup Container

### DIFF
--- a/scripts/gen-did/main.ts
+++ b/scripts/gen-did/main.ts
@@ -32,7 +32,7 @@ async function main() {
 
     if (!mnemonicValidate(paymentSeed)) {
         console.error('Mnemonic is not valid', paymentSeed)
-        process.exit()
+        process.exit(1)
     }
     const paymentKeyPair = Kilt.Utils.Crypto.makeKeypairFromUri(paymentSeed, signingKeyType)
     console.debug(`Payment account address: ${paymentKeyPair.address}`)

--- a/scripts/setup.Dockerfile
+++ b/scripts/setup.Dockerfile
@@ -1,9 +1,9 @@
-FROM docker.io/library/node
+FROM docker.io/library/node:21-bookworm
 
 WORKDIR /app
 RUN apt update && apt install -y openssl jq
 COPY scripts ./scripts
-RUN cd /app/scripts/gen-did && npm install
+RUN cd /app/scripts/gen-did && yarn install
 
 # for output data
 VOLUME /data

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -19,7 +19,7 @@ else
   exit 1
 fi
 echo "Generating DID..."
-npx ts-node scripts/gen-did/main.ts "${PAYMENT_ACCOUNT_SEED}"
+npx ts-node scripts/gen-did/main.ts "${PAYMENT_ACCOUNT_SEED}" || { echo 'my_command failed' ; exit 1; }
 DID=$(cat did-document.json | jq -r .uri)
 echo "DID: ${DID}"
 KEYAGREEMENT_PRIVKEY=$(cat did-secrets.json | jq -r .keyAgreement.privKey)

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -19,7 +19,7 @@ else
   exit 1
 fi
 echo "Generating DID..."
-npx ts-node scripts/gen-did/main.ts "${PAYMENT_ACCOUNT_SEED}" || { echo 'my_command failed' ; exit 1; }
+npx ts-node scripts/gen-did/main.ts "${PAYMENT_ACCOUNT_SEED}" || { echo 'DID generation failed!' ; exit 1; }
 DID=$(cat did-document.json | jq -r .uri)
 echo "DID: ${DID}"
 KEYAGREEMENT_PRIVKEY=$(cat did-secrets.json | jq -r .keyAgreement.privKey)


### PR DESCRIPTION
The setup container throws an error due to unsupported node version, this fixes this issue by pinning the node version of the docker container. 

This PR also terminates the setup script if the DID generation fails. This prevents the creation of faulty config files.