### PR TITLE
Improve Authorize Errors

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,5 +1,3 @@
 pub const OIDC_SESSION_KEY: &str = "oidc_context";
 pub const SESSION_COOKIE_NAME: &str = "opendid";
 pub const ID_TOKEN_VARIABLE_NAME: &str = "ID_TOKEN";
-pub const RESPONSE_TYPE_SESSION_KEY: &str = "response_type";
-pub const REDIRECT_URI_SESSION_KEY: &str = "redirect_uri";

--- a/src/response_type.rs
+++ b/src/response_type.rs
@@ -1,9 +1,9 @@
 use std::str::FromStr;
-
+use serde::{Deserialize, Serialize};
 use crate::error::Error;
 
 // Authorization Code Flow and Implicit Flow are supported.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ResponseType {
     IdToken,
     IdTokenToken,

--- a/src/response_type.rs
+++ b/src/response_type.rs
@@ -1,6 +1,6 @@
-use std::str::FromStr;
-use serde::{Deserialize, Serialize};
 use crate::error::Error;
+use serde::{Deserialize, Serialize};
+use std::str::FromStr;
 
 // Authorization Code Flow and Implicit Flow are supported.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/routes/authentication.rs
+++ b/src/routes/authentication.rs
@@ -116,7 +116,7 @@ async fn get_credential_requirements_handler(
 
     // encode and encrypt it for the receiver
     let msg_json = serde_json::to_string(&msg)
-        .map_err(|e| Error::Internal(format!("serialization error: {}", e.to_string())))?;
+        .map_err(|e| Error::Internal(format!("serialization error: {}", e)))?;
     let msg_bytes = msg_json.as_bytes();
     let our_secretkey = app_state.session_secret_key.clone();
     let others_pubkey = parse_encryption_key_from_lightdid(key_uri.as_str())?;

--- a/src/routes/authentication.rs
+++ b/src/routes/authentication.rs
@@ -303,12 +303,6 @@ async fn post_credential_handler(
         checker.check(&id_token)?;
     }
 
-    // let response_type = ResponseType::from_str(
-    //     &session
-    //         .get::<String>(RESPONSE_TYPE_SESSION_KEY)?
-    //         .ok_or(Error::ResponseType)?,
-    // )?;
-
     let response_type = oidc_context.response_type;
 
     drop(app_state_read);

--- a/src/routes/authentication.rs
+++ b/src/routes/authentication.rs
@@ -17,7 +17,7 @@ use crate::{
     messages::{EncryptedMessage, Message, MessageBody},
     routes::error::Error,
     verify::verify_credential_message,
-    AppState, ValidatedAuthorizeParameters, TokenMetadata, TokenResponse,
+    AppState, TokenMetadata, TokenResponse, ValidatedAuthorizeParameters,
 };
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -332,10 +332,12 @@ async fn post_credential_handler(
             .append_header((
                 "Location",
                 format!(
-                    "{}?code={}&state={}",
+                    "{}?code={}{}",
                     oidc_context.redirect_uri.clone(),
                     code,
-                    oidc_context.state.unwrap_or_default().clone(),
+                    oidc_context
+                        .state
+                        .map_or_else(|| "".to_string(), |state| format!("&state={}", state))
                 ),
             ))
             .finish())
@@ -349,7 +351,9 @@ async fn post_credential_handler(
                     oidc_context.redirect_uri.clone(),
                     id_token,
                     refresh_token,
-                    oidc_context.state.unwrap_or_default().clone(),
+                    oidc_context
+                        .state
+                        .map_or_else(|| "".to_string(), |state| format!("&state={}", state))
                 ),
             ))
             .finish())

--- a/src/routes/authentication.rs
+++ b/src/routes/authentication.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, str::FromStr};
+use std::collections::HashMap;
 
 use actix_session::Session;
 use actix_web::{get, post, web, HttpResponse};
@@ -12,13 +12,12 @@ use tokio::sync::RwLock;
 
 use crate::{
     config::CredentialRequirement,
-    constants::{OIDC_SESSION_KEY, REDIRECT_URI_SESSION_KEY, RESPONSE_TYPE_SESSION_KEY},
+    constants::OIDC_SESSION_KEY,
     kilt::{self, parse_encryption_key_from_lightdid},
     messages::{EncryptedMessage, Message, MessageBody},
-    response_type::ResponseType,
-    routes::{error::Error, AuthorizeQueryParameters},
+    routes::error::Error,
     verify::verify_credential_message,
-    AppState, TokenMetadata, TokenResponse,
+    AppState, AuthorizeParameters, TokenMetadata, TokenResponse,
 };
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -88,7 +87,7 @@ async fn get_credential_requirements_handler(
 
     // get the credential requirements for this specific client. The client ID comes from the session
     let oidc_context = session
-        .get::<AuthorizeQueryParameters>(OIDC_SESSION_KEY)
+        .get::<AuthorizeParameters>(OIDC_SESSION_KEY)
         .map_err(|_| Error::OauthNoSession)?
         .ok_or(Error::OauthInvalidClientId)?;
 
@@ -116,7 +115,8 @@ async fn get_credential_requirements_handler(
     };
 
     // encode and encrypt it for the receiver
-    let msg_json = serde_json::to_string(&msg).unwrap();
+    let msg_json = serde_json::to_string(&msg)
+        .map_err(|_| Error::Internal("serialization error".to_string()))?;
     let msg_bytes = msg_json.as_bytes();
     let our_secretkey = app_state.session_secret_key.clone();
     let others_pubkey = parse_encryption_key_from_lightdid(key_uri.as_str())?;
@@ -180,7 +180,7 @@ async fn post_credential_handler(
 
     // get credential requirements for this client, the client id comes from the session
     let oidc_context = session
-        .get::<AuthorizeQueryParameters>(OIDC_SESSION_KEY)
+        .get::<AuthorizeParameters>(OIDC_SESSION_KEY)
         .map_err(|_| Error::OauthNoSession)?
         .ok_or(Error::OauthInvalidClientId)?;
     let client_configs = {
@@ -303,11 +303,13 @@ async fn post_credential_handler(
         checker.check(&id_token)?;
     }
 
-    let response_type = ResponseType::from_str(
-        &session
-            .get::<String>(RESPONSE_TYPE_SESSION_KEY)?
-            .ok_or(Error::ResponseType)?,
-    )?;
+    // let response_type = ResponseType::from_str(
+    //     &session
+    //         .get::<String>(RESPONSE_TYPE_SESSION_KEY)?
+    //         .ok_or(Error::ResponseType)?,
+    // )?;
+
+    let response_type = oidc_context.response_type;
 
     drop(app_state_read);
 
@@ -325,9 +327,7 @@ async fn post_credential_handler(
 
         let token_metadata = TokenMetadata {
             client_id: oidc_context.client_id.clone(),
-            redirect_uri: session
-                .get(REDIRECT_URI_SESSION_KEY)?
-                .ok_or(Error::RedirectUri)?,
+            redirect_uri: oidc_context.redirect_uri.clone(),
         };
         token_storage
             .insert(code.clone(), (token_response.clone(), token_metadata))
@@ -341,7 +341,7 @@ async fn post_credential_handler(
                     "{}?code={}&state={}",
                     oidc_context.redirect_uri.clone(),
                     code,
-                    oidc_context.state.clone(),
+                    oidc_context.state.unwrap_or_default().clone(),
                 ),
             ))
             .finish())
@@ -355,7 +355,7 @@ async fn post_credential_handler(
                     oidc_context.redirect_uri.clone(),
                     id_token,
                     refresh_token,
-                    oidc_context.state.clone(),
+                    oidc_context.state.unwrap_or_default().clone(),
                 ),
             ))
             .finish())

--- a/src/routes/authentication.rs
+++ b/src/routes/authentication.rs
@@ -17,7 +17,7 @@ use crate::{
     messages::{EncryptedMessage, Message, MessageBody},
     routes::error::Error,
     verify::verify_credential_message,
-    AppState, AuthorizeParameters, TokenMetadata, TokenResponse,
+    AppState, ValidatedAuthorizeParameters, TokenMetadata, TokenResponse,
 };
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -87,7 +87,7 @@ async fn get_credential_requirements_handler(
 
     // get the credential requirements for this specific client. The client ID comes from the session
     let oidc_context = session
-        .get::<AuthorizeParameters>(OIDC_SESSION_KEY)
+        .get::<ValidatedAuthorizeParameters>(OIDC_SESSION_KEY)
         .map_err(|_| Error::OauthNoSession)?
         .ok_or(Error::OauthInvalidClientId)?;
 
@@ -180,7 +180,7 @@ async fn post_credential_handler(
 
     // get credential requirements for this client, the client id comes from the session
     let oidc_context = session
-        .get::<AuthorizeParameters>(OIDC_SESSION_KEY)
+        .get::<ValidatedAuthorizeParameters>(OIDC_SESSION_KEY)
         .map_err(|_| Error::OauthNoSession)?
         .ok_or(Error::OauthInvalidClientId)?;
     let client_configs = {

--- a/src/routes/authentication.rs
+++ b/src/routes/authentication.rs
@@ -347,7 +347,7 @@ async fn post_credential_handler(
             .append_header((
                 "Location",
                 format!(
-                    "{}#id_token={}&refresh_token={}&state={}&token_type=bearer",
+                    "{}#id_token={}&refresh_token={}{}&token_type=bearer",
                     oidc_context.redirect_uri.clone(),
                     id_token,
                     refresh_token,

--- a/src/routes/authentication.rs
+++ b/src/routes/authentication.rs
@@ -116,7 +116,7 @@ async fn get_credential_requirements_handler(
 
     // encode and encrypt it for the receiver
     let msg_json = serde_json::to_string(&msg)
-        .map_err(|_| Error::Internal("serialization error".to_string()))?;
+        .map_err(|e| Error::Internal(format!("serialization error: {}", e.to_string())))?;
     let msg_bytes = msg_json.as_bytes();
     let our_secretkey = app_state.session_secret_key.clone();
     let others_pubkey = parse_encryption_key_from_lightdid(key_uri.as_str())?;

--- a/src/routes/authorize.rs
+++ b/src/routes/authorize.rs
@@ -10,6 +10,13 @@ use crate::{
     constants::OIDC_SESSION_KEY, response_type::ResponseType, routes::error::Error, AppState,
 };
 
+
+/// Unvalidated query parameters for `/authorize`.
+///
+/// Some required parameters are optional in this struct to allow validation
+/// and returning proper errors instead serialization errors.
+///
+/// Convert to [`AuthorizeParameters`] after validating the parameters.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct AuthorizeQueryParameters {
     pub client_id: Option<String>,
@@ -19,6 +26,10 @@ pub struct AuthorizeQueryParameters {
     pub state: Option<String>,
     pub nonce: Option<String>,
 }
+
+/// The valid parameters needed for for `/authorize`.
+///
+/// Can be created from the values of [`AuthorizeQueryParameters`] after validation.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct AuthorizeParameters {
     pub client_id: String,

--- a/src/routes/authorize.rs
+++ b/src/routes/authorize.rs
@@ -16,7 +16,7 @@ use crate::{
 /// Some required parameters are optional in this struct to allow validation
 /// and returning proper errors instead serialization errors.
 ///
-/// Convert to [`AuthorizeParameters`] after validating the parameters.
+/// Convert to [`ValidatedAuthorizeParameters`] after validating the parameters.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct AuthorizeQueryParameters {
     pub client_id: Option<String>,
@@ -31,7 +31,7 @@ pub struct AuthorizeQueryParameters {
 ///
 /// Can be created from the values of [`AuthorizeQueryParameters`] after validation.
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct AuthorizeParameters {
+pub struct ValidatedAuthorizeParameters {
     pub client_id: String,
     pub redirect_uri: Url,
     pub response_type: ResponseType,
@@ -103,7 +103,7 @@ async fn authorize_handler(
         );
     }
 
-    let authorize_parameters = AuthorizeParameters {
+    let validated_authorize_parameters = ValidatedAuthorizeParameters {
         client_id,
         redirect_uri,
         response_type,
@@ -114,14 +114,14 @@ async fn authorize_handler(
 
     match (requirements_empty, &query.nonce) {
         (true, Some(nonce)) => {
-            session.insert(OIDC_SESSION_KEY, authorize_parameters)?;
+            session.insert(OIDC_SESSION_KEY, validated_authorize_parameters)?;
             let redirect_uri_with_nonce = format!("/?nonce={}", nonce);
             Ok(HttpResponse::Found()
                 .append_header(("Location", redirect_uri_with_nonce))
                 .finish())
         }
         _ => {
-            session.insert(OIDC_SESSION_KEY, authorize_parameters)?;
+            session.insert(OIDC_SESSION_KEY, validated_authorize_parameters)?;
             Ok(HttpResponse::Found()
                 .append_header(("Location", "/"))
                 .finish())

--- a/src/routes/authorize.rs
+++ b/src/routes/authorize.rs
@@ -10,7 +10,6 @@ use crate::{
     constants::OIDC_SESSION_KEY, response_type::ResponseType, routes::error::Error, AppState,
 };
 
-
 /// Unvalidated query parameters for `/authorize`.
 ///
 /// Some required parameters are optional in this struct to allow validation

--- a/src/routes/authorize.rs
+++ b/src/routes/authorize.rs
@@ -7,19 +7,25 @@ use tokio::sync::RwLock;
 use url::Url;
 
 use crate::{
-    constants::{OIDC_SESSION_KEY, REDIRECT_URI_SESSION_KEY, RESPONSE_TYPE_SESSION_KEY},
-    response_type::ResponseType,
-    routes::error::Error,
-    AppState,
+    constants::OIDC_SESSION_KEY, response_type::ResponseType, routes::error::Error, AppState,
 };
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct AuthorizeQueryParameters {
-    pub client_id: String,
+    pub client_id: Option<String>,
     pub redirect_uri: String,
-    pub response_type: String,
+    pub response_type: Option<String>,
+    pub scope: Option<String>,
+    pub state: Option<String>,
+    pub nonce: Option<String>,
+}
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct AuthorizeParameters {
+    pub client_id: String,
+    pub redirect_uri: Url,
+    pub response_type: ResponseType,
     pub scope: String,
-    pub state: String,
+    pub state: Option<String>,
     pub nonce: Option<String>,
 }
 
@@ -33,49 +39,99 @@ async fn authorize_handler(
 ) -> Result<HttpResponse, Error> {
     log::info!("GET authorize handler");
     let app_state = app_state.read().await;
-    let redirect_urls: &Vec<url::Url> = &app_state
-        .client_configs
-        .get(&query.client_id)
-        .ok_or(Error::OauthInvalidClientId)?
-        .redirect_urls;
 
-    let requirements_empty = &app_state
-        .client_configs
-        .get(&query.client_id)
-        .ok_or(Error::OauthInvalidClientId)?
-        .requirements
-        .is_empty();
+    // Return an error without redirecting, if the `redirect_uri` is an invalid URL.
+    let redirect_uri =
+        Url::parse(&query.redirect_uri).map_err(|_| Error::OauthInvalidRedirectUri)?;
+
+    // `client_id` must be present.
+    let client_id: String = if let Some(client_id) = &query.client_id {
+        client_id.clone()
+    } else {
+        return error_redirect(
+            redirect_uri,
+            Error::OauthInvalidClientId,
+            query.state.as_deref(),
+        );
+    };
+
+    // `response_type` is required.
+    let response_type: &str = if let Some(response_type) = &query.response_type {
+        response_type
+    } else {
+        return error_redirect(redirect_uri, Error::ResponseType, query.state.as_deref());
+    };
+
+    let client_configs = if let Some(configs) = app_state.client_configs.get(&client_id) {
+        configs
+    } else {
+        return error_redirect(
+            Url::parse(&query.redirect_uri).unwrap(),
+            Error::OauthInvalidClientId,
+            query.state.as_deref(),
+        );
+    };
+
+    let redirect_urls: &Vec<url::Url> = &client_configs.redirect_urls;
+    let requirements_empty = client_configs.requirements.is_empty();
 
     // Support Authorization Code Flow and Implicit Flow.
-    let response_type = ResponseType::from_str(query.response_type.as_str())?;
+    let response_type = ResponseType::from_str(response_type)?;
 
     // Implicit flow must include a nonce.
     if response_type.is_implicit_flow() && query.nonce.is_none() {
-        return Err(Error::InvalidNonce);
+        return error_redirect(redirect_uri, Error::InvalidNonce, query.state.as_deref());
     }
 
-    let is_redirect_uri_in_query = redirect_urls
-        .contains(&Url::parse(&query.redirect_uri).map_err(|_| Error::OauthInvalidRedirectUri)?);
+    let is_redirect_uri_in_query = redirect_urls.contains(&redirect_uri);
     if !is_redirect_uri_in_query {
-        return Err(Error::OauthInvalidRedirectUri);
+        return error_redirect(
+            redirect_uri,
+            Error::OauthInvalidRedirectUri,
+            query.state.as_deref(),
+        );
     }
 
-    session.insert(REDIRECT_URI_SESSION_KEY, query.redirect_uri.clone())?;
-    session.insert(RESPONSE_TYPE_SESSION_KEY, query.response_type.clone())?;
+    let authorize_parameters = AuthorizeParameters {
+        client_id,
+        redirect_uri,
+        response_type,
+        scope: query.scope.clone().unwrap_or_default(),
+        state: query.state.clone(),
+        nonce: query.nonce.clone(),
+    };
 
     match (requirements_empty, &query.nonce) {
         (true, Some(nonce)) => {
-            session.insert(OIDC_SESSION_KEY, query.clone().into_inner())?;
+            session.insert(OIDC_SESSION_KEY, authorize_parameters)?;
             let redirect_uri_with_nonce = format!("/?nonce={}", nonce);
             Ok(HttpResponse::Found()
                 .append_header(("Location", redirect_uri_with_nonce))
                 .finish())
         }
         _ => {
-            session.insert(OIDC_SESSION_KEY, query.clone().into_inner())?;
+            session.insert(OIDC_SESSION_KEY, authorize_parameters)?;
             Ok(HttpResponse::Found()
                 .append_header(("Location", "/"))
                 .finish())
         }
     }
+}
+
+/// Creates a 302 response with an error.
+fn error_redirect(
+    mut redirect_uri: Url,
+    error: Error,
+    state: Option<&str>,
+) -> Result<HttpResponse, Error> {
+    redirect_uri
+        .query_pairs_mut()
+        .append_pair("error", "invalid_request")
+        .append_pair("error_description", &error.to_string());
+    if let Some(state) = state {
+        redirect_uri.query_pairs_mut().append_pair("state", state);
+    };
+    Ok(HttpResponse::Found()
+        .append_header(("Location", redirect_uri.to_string()))
+        .finish())
 }

--- a/src/routes/did.rs
+++ b/src/routes/did.rs
@@ -14,7 +14,7 @@ use crate::{
     },
     routes::error::Error,
     verify::{hex_decode, hex_encode},
-    AppState, AuthorizeQueryParameters,
+    AppState, AuthorizeParameters,
 };
 
 #[derive(serde::Deserialize)]
@@ -68,7 +68,7 @@ async fn login_with_did(
 
     // get requirements for this client, the client id comes from the session
     let oidc_context = session
-        .get::<AuthorizeQueryParameters>(OIDC_SESSION_KEY)
+        .get::<AuthorizeParameters>(OIDC_SESSION_KEY)
         .map_err(|_| Error::OauthNoSession)?
         .ok_or(Error::OauthInvalidClientId)?;
 
@@ -220,7 +220,7 @@ async fn login_with_did(
                 oidc_context.redirect_uri.clone(),
                 id_token,
                 refresh_token,
-                oidc_context.state.clone(),
+                oidc_context.state.unwrap_or_default().clone(),
             ),
         ))
         .finish())

--- a/src/routes/did.rs
+++ b/src/routes/did.rs
@@ -14,7 +14,7 @@ use crate::{
     },
     routes::error::Error,
     verify::{hex_decode, hex_encode},
-    AppState, AuthorizeParameters,
+    AppState, ValidatedAuthorizeParameters,
 };
 
 #[derive(serde::Deserialize)]
@@ -68,7 +68,7 @@ async fn login_with_did(
 
     // get requirements for this client, the client id comes from the session
     let oidc_context = session
-        .get::<AuthorizeParameters>(OIDC_SESSION_KEY)
+        .get::<ValidatedAuthorizeParameters>(OIDC_SESSION_KEY)
         .map_err(|_| Error::OauthNoSession)?
         .ok_or(Error::OauthInvalidClientId)?;
 

--- a/src/routes/did.rs
+++ b/src/routes/did.rs
@@ -216,11 +216,13 @@ async fn login_with_did(
         .append_header((
             "Location",
             format!(
-                "{}#id_token={}&refresh_token={}&state={}&token_type=bearer",
+                "{}#id_token={}&refresh_token={}{}&token_type=bearer",
                 oidc_context.redirect_uri.clone(),
                 id_token,
                 refresh_token,
-                oidc_context.state.unwrap_or_default().clone(),
+                oidc_context
+                    .state
+                    .map_or_else(|| "".to_string(), |state| format!("&state={}", state))
             ),
         ))
         .finish())


### PR DESCRIPTION
So far, the service will just return 40x errors when something goes wrong calling `authorize`. The specs defines a way to return errors if the `redirect_uri` is valid. So the user can be redirected back to the orignial webpage which is supposed to handle that error for better user experience. 

This functionality still needs testing once [the Test Suite](https://github.com/KILTprotocol/opendid/pull/66) lands. 